### PR TITLE
Added clearing of Composer cache for artifact packages

### DIFF
--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -43,6 +43,8 @@ abstract class BaseCommand extends Command
             $output->writeln('<info>Using configuration:</info> ' . $this->configurationFile);
             $output->writeln('<info>Changed working dir:</info> ' . $this->workingDir);
         }
+
+        $this->conductor->setOutput($output);
     }
 
     /**

--- a/src/Conductor.php
+++ b/src/Conductor.php
@@ -4,6 +4,7 @@ namespace MyBuilder\Conductor;
 
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class Conductor
 {
@@ -11,6 +12,8 @@ class Conductor
      * @var Filesystem
      */
     private $fileSystem;
+
+    private $output;
 
     public function __construct(Filesystem $fileSystem)
     {
@@ -24,7 +27,41 @@ class Conductor
 
         $results = array();
         foreach ($finder->in($paths) as $file) {
-            $results[] = $packageZipper->zip($file);
+            if ($this->output && OutputInterface::VERBOSITY_VERBOSE <= $this->output->getVerbosity()) {
+                $this->output->writeln('<info>Package file:</info> ' . $file);
+            }
+            $zip = $packageZipper->zip($file);
+
+            // remove composer cache for custom artifact packages
+            // Composer would pick cached ones instead of artifact folder
+            if (!empty($_SERVER['HOME']) && $this->fileSystem->exists($_SERVER['HOME'])) {
+                $packageDefinition = json_decode(file_get_contents($file));
+                $path = explode("/", $packageDefinition->name);
+
+                $baseCachePath = $_SERVER['HOME'] . '/.composer/cache/files/';
+                $vendorPath = $baseCachePath . $path[0];
+                if ($this->fileSystem->exists($vendorPath)) {
+                    if ($this->output && OutputInterface::VERBOSITY_VERBOSE <= $this->output->getVerbosity()) {
+                        $this->output->writeln('<info>Searching for Composer cache directory:'
+                            . $path[1] . ' in ' . $vendorPath . '</info>');
+                    }
+                    $cacheFinder = new Finder();
+                    $folders = $cacheFinder->directories()->depth('== 0')->name($path[1])->in(array($vendorPath));
+                    foreach ($folders as $folder) {
+                        try {
+                            $this->fileSystem->remove($folder);
+                            if ($this->output && OutputInterface::VERBOSITY_VERBOSE <= $this->output->getVerbosity()) {
+                                $this->output->writeln("<info>Removed '$folder' directory</info>");
+                            }
+                        } catch (\Exception $e) {
+                            $this->output->writeln("<error>Failed to remove '{$vendorPath}/{$folder}'"
+                                . " directory from Composer cache. You may be getting an outdated artifact package</error>");
+                        }
+                    }
+                }
+            }
+
+            $results[] = $zip;
         }
 
         return $results;
@@ -36,6 +73,9 @@ class Conductor
         $finder->files()->name('replace_with_symlink.path');
 
         foreach ($finder->in($rootPath) as $file) {
+            if ($this->output && OutputInterface::VERBOSITY_VERBOSE <= $this->output->getVerbosity()) {
+                $this->output->writeln('<info>Package symlink path file:</info> ' . $file);
+            }
             $this->symlinkPackageToVendor(file_get_contents($file), dirname($file));
         }
     }
@@ -47,5 +87,20 @@ class Conductor
         $this->fileSystem->rename($vendorPath, $vendorPath . '_linked', true);
         $this->fileSystem->symlink($relative, $vendorPath);
         $this->fileSystem->remove($vendorPath . '_linked');
+
+        if ($this->output && OutputInterface::VERBOSITY_VERBOSE <= $this->output->getVerbosity()) {
+            $this->output->writeln('<info>Package path:</info> ' . $packagePath
+                . ' <info>Real package path:</info> ' . realpath($packagePath . '/../')
+                . ' <info>Vendor path:</info> ' . $vendorPath . '/../'
+                . ' <info>Real vendor path:</info> ' . realpath($vendorPath . '/../')
+                . ' <info>Relative path:</info> ' . $relative);
+        }
+    }
+
+    public function setOutput(OutputInterface $output)
+    {
+        $this->output = $output;
+
+        return $this;
     }
 }


### PR DESCRIPTION
Composer picks cached .zip packages instead of using 'artifact' directory prepared by Conductor if the versions are the same. This clears the cache entries for those packages when Conductor creates zip files.
